### PR TITLE
Remove space in xforms dependency coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In `net.cgrand.xforms.io`:
 Add this dependency to your project:
 
 ```clj
-[net.cgrand /xforms "0.12.1"]
+[net.cgrand/xforms "0.12.1"]
 ```
 
 ```clj


### PR DESCRIPTION
Not sure if this was intentional, but may trip others up who just copy/paste directly into their `project.clj`.