### PR TITLE
Remove reflection warnings from min/max rfs

### DIFF
--- a/src/net/cgrand/xforms/rfs.cljc
+++ b/src/net/cgrand/xforms/rfs.cljc
@@ -28,7 +28,7 @@
            :else 0))))
   
 (defn minimum
- ([comparator]
+ ([#?(:clj ^java.util.Comparator comparator :cljs comparator)]
    (fn
      ([] nil)
      ([x] x)
@@ -46,7 +46,7 @@
      ([a b] (if (or (#?(:clj identical? :cljs keyword-identical?) ::+∞ a) (pos? (#?(:clj .compare :cljs cmp) comparator a b))) b a)))))
 
 (defn maximum
-  ([comparator]
+  ([#?(:clj ^java.util.Comparator comparator :cljs comparator)]
     (fn
      ([] nil)
      ([x] x)


### PR DESCRIPTION
This change just copies the existing type hints from the other arity definitions.