### PR TITLE
upgrade to latest macrovich

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Evaluation count : 24 in 6 samples of 4 calls.
 
 ## Changelog
 
+### 0.19.3
+
+ * Bump `net.cgrand/macrovich` so Clojure and ClojureScript remain `provided` and are not pulled in transitively
+
 ### 0.19.0
 
 `time` allows to measure time spent in one transducer (excluding time spent downstream).

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject net.cgrand/xforms "0.19.2"
+(defproject net.cgrand/xforms "0.19.3-SNAPSHOT"
   :description "Extra transducers for Clojure"
   :url "https://github.com/cgrand/xforms"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  [org.clojure/clojurescript "1.9.293" :scope "provided"]
-                 [net.cgrand/macrovich "0.2.0"]])
+                 [net.cgrand/macrovich "0.2.1"]])


### PR DESCRIPTION
macrovich 0.2.0 transitively pulls in clojure/script as a dependency. This has been fixed in 0.2.1