### PR TITLE
Add compatibility with babashka

### DIFF
--- a/src/net/cgrand/xforms.cljc
+++ b/src/net/cgrand/xforms.cljc
@@ -99,7 +99,8 @@
                     (not (arities 2)) (conj (let [[[acc karg varg] & body] (arities 3)]
                                               `([~acc [~karg ~varg]] ~@body))))]
     `(reify
-       ~@(macros/case :clj '[clojure.lang.Fn])
+       #?@(:bb [] ;; babashka currently only supports reify with one Java interface at a time
+           :default [~@(macros/case :clj '[clojure.lang.Fn])])
        KvRfable
        (some-kvrf [this#] this#)
        ~(macros/case :cljs `core/IFn :clj 'clojure.lang.IFn)

--- a/test/net/cgrand/xforms_test.cljc
+++ b/test/net/cgrand/xforms_test.cljc
@@ -94,7 +94,8 @@
   (is (= {0 :ok 2 :ok 4 :ok 6 :ok 8 :ok} (x/without (zipmap (range 10) (repeat :ok)) (filter odd?) (range 20))))
   (is (= #{0 2 4 6 8 } (x/without (set (range 10)) (filter odd?) (range 20)))))
 
-#?(:clj
+#?(:bb nil ;; babashka doesn't currently support calling iterator on range type
+   :clj
     (deftest iterator
       (is (true? (.hasNext (x/iterator x/count (.iterator (range 5))))))
       (is (is (= [5] (iterator-seq (x/iterator x/count (.iterator (range 5)))))))


### PR DESCRIPTION
As discussed on Twitter:

https://twitter.com/cgrand/status/1463287363577253888

These changes make xforms compatible with babashka. 

Needs changes in bb too which will be released soon, but already available through these links:

mac:
https://23897-201467090-gh.circle-artifacts.com/0/release/babashka-0.6.6-SNAPSHOT-macos-amd64.tar.gz

linux:
https://23896-201467090-gh.circle-artifacts.com/0/release/babashka-0.6.6-SNAPSHOT-linux-amd64-static.tar.gz

To run tests with bb:

```
$ lein classpath > .classpath
$ ./bb -cp $(cat .classpath):test -e "(require '[net.cgrand.xforms-test] '[clojure.test :as t]) (t/run-tests 'net.cgrand.xforms-test)"

Testing net.cgrand.xforms-test

Ran 6 tests containing 31 assertions.
0 failures, 0 errors.
{:test 6, :pass 31, :fail 0, :error 0, :type :summary}
``` 